### PR TITLE
【Fixed】application.rbに不要ファイルが生成されないよう改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,10 @@ module Achieve
           request_specs: false
         g.fixture_replacement :factory_girl, dir: "spec/factories"
     end
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#3 `rails g`コマンドの際にいらないファイルが生成されないよう改善しました。

・以下を参考にapplication.rbに設定追加。
http://blog.willnet.in/entry/2012/09/02/220124